### PR TITLE
Bug no filing text

### DIFF
--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -3,7 +3,7 @@
 .cookie-info
   Cookie in oven:
   - if @oven.cookie
-    1 cookie with #{@oven.cookie.fillings || "no fillings"}
+    1 cookie with #{@oven.cookie.fillings.presence || "no fillings"}
     - if @oven.cookie.ready?
       (Your Cookie is Ready)
       = button_to "Retrieve Cookie", empty_oven_path, class: 'button tiny'

--- a/app/views/store/index.html.haml
+++ b/app/views/store/index.html.haml
@@ -12,5 +12,5 @@
       %li
         = pluralize(cookies.count, "Cookie")
         with
-        = fillings || "no filling"
+        = fillings.presence || "no filling"
     

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -30,12 +30,9 @@ feature 'Cooking cookies' do
     user = create_and_signin
     oven = user.ovens.first
 
-    oven = FactoryGirl.create(:oven, user: user)
     visit oven_path(oven)
-
     click_link_or_button 'Prepare Cookie'
     click_button 'Mix and bake'
-
     expect(page).to have_content 'no fillings'
 
     click_button 'Retrieve Cookie'
@@ -80,5 +77,4 @@ feature 'Cooking cookies' do
       expect(page).to have_content '3 Cookies'
     end
   end
-
 end

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -26,6 +26,19 @@ feature 'Cooking cookies' do
     end
   end
 
+  scenario 'Cooking a cookie with no fillings' do
+    user = create_and_signin
+    oven = user.ovens.first
+
+    oven = FactoryGirl.create(:oven, user: user)
+    visit oven_path(oven)
+
+    click_link_or_button 'Prepare Cookie'
+    click_button 'Mix and bake'
+
+    expect(page).to have_content 'no fillings'
+  end
+
   scenario 'Trying to bake a cookie while oven is full' do
     user = create_and_signin
     oven = user.ovens.first
@@ -63,4 +76,5 @@ feature 'Cooking cookies' do
       expect(page).to have_content '3 Cookies'
     end
   end
+
 end

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -37,6 +37,10 @@ feature 'Cooking cookies' do
     click_button 'Mix and bake'
 
     expect(page).to have_content 'no fillings'
+
+    click_button 'Retrieve Cookie'
+    visit root_path
+    expect(page).to have_content 'no filling'
   end
 
   scenario 'Trying to bake a cookie while oven is full' do


### PR DESCRIPTION
# What

* cookie with no fillings display text "no fillings" after emerging from oven
* cookie with no filling displays text "no filling" in store inventory
* test coverage added for bug

# Why

`""` is truthy so it does not work in `"" || "default"` expression. `presence` can be used to return `nil` for `""` case and allow `||` to work as intended.
