### PR TITLE
Batch cookies

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -22,6 +22,6 @@ class CookiesController < ApplicationController
   private
 
   def cookie_params
-    params.require(:cookie).permit(:fillings)
+    params.require(:cookie).permit(:fillings, :batch)
   end
 end

--- a/app/views/cookies/new.html.haml
+++ b/app/views/cookies/new.html.haml
@@ -7,7 +7,12 @@
   .row
     .small-8.columns
       = f.text_field :fillings
-
+  .row
+    .small-8.columns
+      = f.label :batch, "Batch Size"
+  .row
+    .small-8.columns
+      = f.text_field :batch
   .row
     .small-8.columns
       = f.submit 'Mix and bake', class: 'button'

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -4,7 +4,7 @@
   .cookie-info
     Cookie in oven:
     - if @oven.cookie
-      1 cookie with #{@oven.cookie.fillings.presence || "no fillings"}
+      #{pluralize(@oven.cookie.batch, "cookie")} with #{@oven.cookie.fillings.presence || "no fillings"}
       - if @oven.cookie.ready?
         (Your Cookie is Ready)
         = button_to "Retrieve Cookie", empty_oven_path(@oven), class: 'button tiny'

--- a/app/views/store/index.html.haml
+++ b/app/views/store/index.html.haml
@@ -10,7 +10,7 @@
   %ul
     - current_user.stored_cookies.group_by(&:fillings).each_pair do |fillings, cookies|
       %li
-        = pluralize(cookies.count, "Cookie")
+        = pluralize(cookies.map(&:batch).sum, "Cookie")
         with
         = fillings.presence || "no filling"
     

--- a/db/migrate/20210403080123_add_batch_to_cookie.rb
+++ b/db/migrate/20210403080123_add_batch_to_cookie.rb
@@ -1,0 +1,5 @@
+class AddBatchToCookie < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cookies, :batch, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210402204532) do
+ActiveRecord::Schema.define(version: 20210403080123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20210402204532) do
     t.integer "storage_id"
     t.string "storage_type"
     t.boolean "ready"
+    t.integer "batch", default: 1
   end
 
   create_table "ovens", force: :cascade do |t|

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -119,13 +119,14 @@ feature 'Cooking cookies' do
     click_link_or_button 'Prepare Cookie'
     fill_in 'Batch Size', with: batch
     click_button 'Mix and bake'
-    expect(page).to contain(batch)
+    expect(page).to have_content(batch)
 
     perform_jobs!
-    expect(page).to contain(batch)
+    refresh
+    expect(page).to have_content(batch)
 
     click_button 'Retrieve Cookie'
     visit root_path
-    expect(page).to contain(batch)
+    expect(page).to have_content(batch)
   end
 end

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -110,4 +110,22 @@ feature 'Cooking cookies' do
     end
   end
 
+  scenario 'Baking a batch of cookies' do
+    batch = 10
+    user = create_and_signin
+    oven = user.ovens.first
+
+    visit oven_path(oven)
+    click_link_or_button 'Prepare Cookie'
+    fill_in 'Batch Size', with: batch
+    click_button 'Mix and bake'
+    expect(page).to contain(batch)
+
+    perform_jobs!
+    expect(page).to contain(batch)
+
+    click_button 'Retrieve Cookie'
+    visit root_path
+    expect(page).to contain(batch)
+  end
 end

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -126,7 +126,13 @@ feature 'Cooking cookies' do
     expect(page).to have_content(batch)
 
     click_button 'Retrieve Cookie'
+    click_link_or_button 'Prepare Cookie'
+    click_button 'Mix and bake'
+    perform_jobs!
+    refresh
+    click_button 'Retrieve Cookie'
+
     visit root_path
-    expect(page).to have_content(batch)
+    expect(page).to have_content(batch + 1)
   end
 end


### PR DESCRIPTION
# What

* add `batch` column to cookies and default to 1
* use batch size in forms and when displaying cookie counts
* test coverage of batch entry, display, and sum

# Why

A batch count simulates a sheet of the same cookies being made in a simple manner.