### PR TITLE
Make "Prepare Cookie" button first for mobile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'pg', '~> 0.18'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 
+gem "browser"
+
 group :development do
   gem 'selenium-webdriver'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    browser (5.3.1)
     builder (3.2.3)
     capybara (3.16.2)
       addressable
@@ -295,6 +296,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  browser
   capybara
   coffee-rails
   database_cleaner

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -1,4 +1,7 @@
 .oven-channel{data: {oven: @oven.id}}
+  - if browser.device.mobile?
+    = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button', style: 'margin-top: 1em;'
+
   %h3= @oven.name
 
   .cookie-info
@@ -13,4 +16,5 @@
 
   %br
 
-  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
+  - unless browser.device.mobile?
+    = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'


### PR DESCRIPTION
# What

* add browser gem to detect mobile
* allow for two button placements in view, with slight style adjustment to mobile button margin

# Why

The browser gem is a Rails integrated way to detect mobile devices. It can be tested by running `rails server -b 0.0.0.0` and then visiting the ip from `ipconfig getifaddr en0` on a mobile device at port 3000. An alternative approach could be to use css media queries.